### PR TITLE
Account for new tar format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python_gardenlinux_lib"
-version = "0.4.0"
+version = "0.4.1"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/python_gardenlinux_lib/oras/registry.py
+++ b/src/python_gardenlinux_lib/oras/registry.py
@@ -637,7 +637,6 @@ class GlociRegistry(Registry):
         return layer
 
     def push_from_tar(self, architecture: str, version: str, cname: str, tar: str):
-        assert tar.endswith(".tar.xz")
         tmpdir = tempfile.mkdtemp()
         extract_tar(tar, tmpdir)
 
@@ -679,14 +678,10 @@ def extract_tar(tar: str, tmpdir: str):
     :param tar: str the full path to the tarball
     :param tmpdir: str the tmp directory to extract to
     """
-    fullname = os.path.basename(tar).removesuffix(".tar.xz")
     try:
         tar_obj = tarfile.open(tar)
         tar_obj.extractall(filter="data", path=tmpdir)
         tar_obj.close()
-        for file in os.listdir(f"{tmpdir}/{fullname}"):
-            shutil.move(f"{tmpdir}/{fullname}/{file}", tmpdir)
-        shutil.rmtree(f"{tmpdir}/{fullname}", ignore_errors=True)
         for file in os.listdir(tmpdir):
             if file.endswith(".pxe.tar.gz"):
                 logger.info(f"Found nested artifact {file}")


### PR DESCRIPTION
Now, that we want to download the artifacts no longer from S3 one level
of folder nesting is missing, this commit includes the required changes.
Also the assertion for the .tar.xz suffix is removed.

Signed-off-by: Malte Münch <muench@b1-systems.de>
