### PR TITLE
Reference nested GitHub actions to always use `main`

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@feature/gardenlinux-restructure
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@main
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@feature/gardenlinux-restructure
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@main
     - id: matrix
       shell: bash
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes access to called nested GitHub actions using a former branch name instead of `main`. Using a construct like `@${{ github.ref_name }}` is unfortunately not supported.