### PR TITLE
Change the default version referenced to use `main` instead of a branch

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
   version:
     description: GardenLinux Python library version
-    default: "feature/gardenlinux-restructure"
+    default: "main"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the default version to point to `main` to reflect the already the nested actions changed in #107.