### PR TITLE
Add support to cache `pip` dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,9 +4,6 @@ inputs:
     version:
         description: GardenLinux Python library version
         default: "main"
-    dev:
-        description: Install development dependencies
-        default: false
 runs:
     using: composite
     steps:
@@ -14,6 +11,7 @@ runs:
           uses: actions/setup-python@v5
           with:
               python-version: "3.13"
+              cache: 'pip'
         - name: Install GardenLinux Python library
           shell: bash
           run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to cache `pip` installed dependencies for future use.