### PR TITLE
Move `CName` parser to a separate class

### DIFF
--- a/src/gardenlinux/features/__init__.py
+++ b/src/gardenlinux/features/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from .cname import CName
 from .parser import Parser
 
-__all__ = ["Parser"]
+__all__ = ["CName", "Parser"]

--- a/src/gardenlinux/features/cname.py
+++ b/src/gardenlinux/features/cname.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+from typing import Optional
+import re
+
+
+class CName(object):
+    def __init__(self, cname, arch=None, version=None):
+        self._arch = None
+        self._flavor = None
+        self._commit_id = None
+        self._version = None
+
+        re_match = re.match(
+            "([a-zA-Z0-9]+([\\_\\-][a-zA-Z0-9]+)*?)(-([a-z0-9]+)(-([a-z0-9.]+)-([a-z0-9]+))*)?$",
+            cname,
+        )
+
+        assert re_match, f"Not a valid GardenLinux canonical name {cname}"
+
+        if re_match.lastindex == 1:
+            self._flavor = re_match[1]
+        else:
+            self._commit_id = re_match[7]
+            self._flavor = re_match[1]
+            self._version = re_match[6]
+
+            if re_match[2] is None:
+                self._flavor += re_match[3]
+            else:
+                self._arch = re_match[4]
+
+        if self._arch is None and arch is not None:
+            self._arch = arch
+
+        if self._version is None and version is not None:
+            re_match = re.match("([a-z0-9.]+)(-([a-z0-9]+))?$", version)
+            assert re_match, f"Not a valid version {version}"
+
+            self._commit_id = re_match[3]
+            self._version = re_match[1]
+
+    @property
+    def arch(self) -> Optional[str]:
+        return self._arch
+
+    @property
+    def cname(self) -> str:
+        cname = self._flavor
+
+        if self._arch is not None:
+            cname += f"-{self._arch}"
+
+        if self._commit_id is not None:
+            cname += f"-{self.version_and_commit_id}"
+
+        return cname
+
+    @property
+    def commit_id(self) -> Optional[str]:
+        return self._commit_id
+
+    @property
+    def flavor(self) -> str:
+        return self._flavor
+
+    @property
+    def version(self) -> Optional[str]:
+        return self._version
+
+    @property
+    def version_and_commit_id(self) -> Optional[str]:
+        if self._commit_id is None:
+            return None
+
+        return f"{self._version}-{self._commit_id}"

--- a/src/gardenlinux/features/parser.py
+++ b/src/gardenlinux/features/parser.py
@@ -222,57 +222,6 @@ class Parser(object):
         return set(cname.split("-"))
 
     @staticmethod
-    def get_flavor_from_cname(cname: str, get_arch: bool = True) -> str:
-        """
-        Extracts the flavor from a canonical name.
-
-        This method parses a Garden Linux canonical name (cname) and extracts
-        the flavor component, with or without the architecture suffix.
-
-        Example canonical names:
-        - "aws-gardener_prod-amd64"
-        - "azure-gardener_prod_tpm2_trustedboot-amd64-1312.2-80ffcc87"
-
-        The flavor is the platform plus feature string (e.g., "aws-gardener_prod")
-
-        Args:
-            cname (str): Canonical name of an image
-            get_arch (bool): Whether to include the architecture in the returned flavor
-                            If True: returns "aws-gardener_prod-amd64"
-                            If False: returns "aws-gardener_prod"
-
-        Returns:
-            str: The extracted flavor string, with or without architecture
-        """
-        # Use regex to extract components from the canonical name
-        # This handles complex cnames with version and commit hash
-        re_match = re.match(
-            "([a-zA-Z0-9]+([\\_\\-][a-zA-Z0-9]+)*?)(-([a-z0-9]+)(-([a-z0-9.]+)-([a-z0-9]+))*)?$",
-            cname,
-        )
-
-        assert re_match, f"Not a valid GardenLinux canonical name {cname}"
-
-        if re_match.lastindex == 1:
-            data_splitted = re_match[1].split("-", 1)
-
-            flavor = data_splitted[0]
-
-            if len(data_splitted) > 1:
-                if get_arch is True:
-                    arch = data_splitted[1]
-                else:
-                    flavor += "-" + data_splitted[1]
-        else:
-            arch = re_match[4]
-            flavor = re_match[1]
-        # Add architecture if requested
-        if get_arch and arch:
-            return f"{flavor}-{arch}"
-        else:
-            return flavor
-
-    @staticmethod
     def _get_filter_set_callable(filter_set, additional_filter_func):
         def filter_func(node):
             additional_filter_result = (

--- a/tests/features/test_cname.py
+++ b/tests/features/test_cname.py
@@ -1,0 +1,32 @@
+import pytest
+
+from gardenlinux.features import CName
+
+
+@pytest.mark.parametrize(
+    "input_cname, expected_output",
+    [
+        (
+            "aws-gardener_prod",
+            "aws-gardener_prod",
+        ),
+        (
+            "metal-khost_dev",
+            "metal-khost_dev",
+        ),
+        (
+            "metal_pxe",
+            "metal_pxe",
+        ),
+    ],
+)
+def test_cname_flavor(input_cname: str, expected_output: dict):
+    """
+    Tests if cname returns the dict with expected features.
+
+    If you discover that this test failed, you may want to verify if the included
+    features have changed since writing this test. In this case, update the expected output accordingly.
+    You can print the output of cname so you have the dict in the expected format.
+    """
+    cname = CName(input_cname)
+    assert cname.flavor == expected_output

--- a/tests/features/test_features_parser.py
+++ b/tests/features/test_features_parser.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gardenlinux.features import Parser
-from .constants import GL_ROOT_DIR
+from ..constants import GL_ROOT_DIR
 
 
 @pytest.mark.parametrize(
@@ -58,13 +58,13 @@ from .constants import GL_ROOT_DIR
         ),
     ],
 )
-def test_get_features_dict(input_cname: str, expected_output: dict):
+def test_parser_filter_as_dict(input_cname: str, expected_output: dict):
     """
-    Tests if get_features_dict returns the dict with expected features.
+    Tests if parser_filter_as_dict returns the dict with expected features.
 
     If you discover that this test failed, you may want to verify if the included
     features have changed since writing this test. In this case, update the expected output accordingly.
-    You can print the output of get_features_dict so you have the dict in the expected format.
+    You can print the output of parser_filter_as_dict so you have the dict in the expected format.
     """
     features_dict = Parser(GL_ROOT_DIR).filter_as_dict(input_cname)
     assert features_dict == expected_output


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces `gardenlinux.features.CName` to parse and work with GardenLinux Canonical Name based parsed metadata like "flavor", "version" or "commit_id".