### PR TITLE
Pin GitHub actions to 0.7.0

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@main
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.7.0
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@main
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.7.0
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
     version:
         description: GardenLinux Python library version
-        default: "main"
+        default: "0.7.0"
 runs:
     using: composite
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR pins the GitHub actions called to tag `0.7.0`.
