### PR TITLE
Fix GitHub action `setup` to allow "setup-python" with `pip` cache enabled

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,6 +7,12 @@ inputs:
 runs:
     using: composite
     steps:
+        - name: Verify requirements.txt for "actions/setup-python" with enabled "pip" cache
+          shell: bash
+          run: |
+            if [ ! -f "requirements.txt" ]; then
+                echo "python-gardenlinux-lib @ git+https://github.com/gardenlinux/python-gardenlinux-lib.git@${{ inputs.version }}" | tee -a requirements.txt
+            fi
         - name: Set up Python 3.13
           uses: actions/setup-python@v5
           with:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with "setup-python" expecting a `requirements.txt` for hashing if dependency caching like `pip` is enabled. This action should be callable in workflows even if such a file does not exist. Therefore we create it manually.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3097