### PR TITLE
Fix mixed `cname` with separate version argument parsing

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.8
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.8
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
     version:
         description: GardenLinux Python library version
-        default: "0.8.7"
+        default: "0.8.8"
 runs:
     using: composite
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gardenlinux"
-version = "0.8.7"
+version = "0.8.8"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/gardenlinux/features/__main__.py
+++ b/src/gardenlinux/features/__main__.py
@@ -6,6 +6,7 @@ gl-features-parse main entrypoint
 """
 
 import argparse
+import logging
 import os
 import re
 import sys
@@ -81,7 +82,13 @@ def main() -> None:
         try:
             version_data = get_version_and_commit_id_from_files(gardenlinux_root)
             version = f"{version_data[0]}-{version_data[1]}"
-        except:
+        except RuntimeError as exc:
+            logging.debug(
+                "Failed to parse version information for GL root '{0}': {1}".format(
+                    gardenlinux_root, exc
+                )
+            )
+
             version = args.default_version
 
     if args.cname:

--- a/src/gardenlinux/features/__main__.py
+++ b/src/gardenlinux/features/__main__.py
@@ -65,24 +65,24 @@ def main() -> None:
         args.cname
     ), "Please provide either `--features` or `--cname` argument"
 
-    arch = None
+    arch = args.arch
     flavor = None
     commit_id = None
     gardenlinux_root = path.dirname(args.feature_dir)
-    version = None
-
-    if args.arch is not None:
-        arch = args.arch
-
-    if args.version is not None:
-        version = args.version
+    version = args.version
 
     if arch is None or arch == "":
         arch = args.default_arch
 
+    if gardenlinux_root == "":
+        gardenlinux_root = "."
+
     if version is None or version == "":
-        version_data = get_version_and_commit_id_from_files(gardenlinux_root)
-        version = f"{version_data[0]}-{version_data[1]}"
+        try:
+            version_data = get_version_and_commit_id_from_files(gardenlinux_root)
+            version = f"{version_data[0]}-{version_data[1]}"
+        except:
+            version = args.default_version
 
     if args.cname:
         cname = CName(args.cname, arch=arch, version=version)
@@ -105,12 +105,6 @@ def main() -> None:
         raise RuntimeError("Version not specified and no default version set")
 
     feature_dir_name = path.basename(args.feature_dir)
-
-    if gardenlinux_root == "":
-        gardenlinux_root = "."
-
-    if gardenlinux_root == "":
-        gardenlinux_root = "."
 
     additional_filter_func = lambda node: node not in args.ignore
 
@@ -198,6 +192,9 @@ def get_version_and_commit_id_from_files(gardenlinux_root: str) -> tuple[str, st
     if os.access(path.join(gardenlinux_root, "VERSION"), os.R_OK):
         with open(path.join(gardenlinux_root, "VERSION"), "r") as fp:
             version = fp.read().strip()
+
+    if commit_id is None or version is None:
+        raise RuntimeError("Failed to read version or commit ID from files")
 
     return (version, commit_id)
 

--- a/src/gardenlinux/features/cname_main.py
+++ b/src/gardenlinux/features/cname_main.py
@@ -44,19 +44,19 @@ def main():
 
     assert re_match, f"Not a valid GardenLinux canonical name {args.cname}"
 
-    arch = None
+    arch = args.arch
     gardenlinux_root = dirname(args.feature_dir)
     version = args.version
 
-    if args.arch is not None:
-        arch = args.arch
-
-    if args.version is not None:
-        version = args.version
+    if gardenlinux_root == "":
+        gardenlinux_root = "."
 
     if not version:
-        version_data = get_version_and_commit_id_from_files(gardenlinux_root)
-        version = f"{version_data[0]}-{version_data[1]}"
+        try:
+            version_data = get_version_and_commit_id_from_files(gardenlinux_root)
+            version = f"{version_data[0]}-{version_data[1]}"
+        except:
+            pass
 
     cname = CName(args.cname, arch=arch, version=version)
 

--- a/src/gardenlinux/features/cname_main.py
+++ b/src/gardenlinux/features/cname_main.py
@@ -8,6 +8,7 @@ gl-cname main entrypoint
 from functools import reduce
 from os.path import basename, dirname
 import argparse
+import logging
 import re
 
 from .cname import CName
@@ -55,8 +56,12 @@ def main():
         try:
             version_data = get_version_and_commit_id_from_files(gardenlinux_root)
             version = f"{version_data[0]}-{version_data[1]}"
-        except:
-            pass
+        except RuntimeError as exc:
+            logging.warning(
+                "Failed to parse version information for GL root '{0}': {1}".format(
+                    gardenlinux_root, exc
+                )
+            )
 
     cname = CName(args.cname, arch=arch, version=version)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances handling corner cases of flavors given as input and `arch` and/or `version` (as well as "default"-argument variants) to return the expected GardenLinux canonical name. Changes are code cleanup related and fix a possible error that `None-None` is not a valid version.

This PR merged code should be tagged "0.8.8".