### PR TITLE
make modifiers in s3 artifact manifest a list

### DIFF
--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -148,7 +148,7 @@ class S3Artifacts(object):
             "build_timestamp": datetime.fromtimestamp(release_timestamp).isoformat(),
             "gardenlinux_epoch": cname_object.version.split(".", 1)[0],
             "logs": None,
-            "modifiers": feature_set,
+            "modifiers": feature_list,
             "require_uefi": "_usi" in feature_list,
             "secureboot": "_trustedboot" in feature_list,
             "published_image_metadata": None,


### PR DESCRIPTION
**What this PR does / why we need it**:

Make modifiers in s3 artifact manifest a list to parse this better in GLCI.
We aligned that having a real list is more correct.

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/commit/09ea136d8720a557381fb586431d19e5919d1b54 and https://github.com/gardenlinux/python-gardenlinux-lib/commit/a7545af15d3a1fa96675b24807eace643483da96 introduced a breaking change that breaks GLCI.
