### PR TITLE
 make gardenlinux_epoch in s3 artifact manifest an integer 

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.1
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.2
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.1
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.2
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
     version:
         description: GardenLinux Python library version
-        default: "0.8.1"
+        default: "0.8.2"
 runs:
     using: composite
     steps:

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -146,7 +146,7 @@ class S3Artifacts(object):
             "base_image": None,
             "build_committish": commit_hash,
             "build_timestamp": datetime.fromtimestamp(release_timestamp).isoformat(),
-            "gardenlinux_epoch": cname_object.version.split(".", 1)[0],
+            "gardenlinux_epoch": int(cname_object.version.split(".", 1)[0]),
             "logs": None,
             "modifiers": feature_list,
             "require_uefi": "_usi" in feature_list,


### PR DESCRIPTION
**What this PR does / why we need it**:

[make gardenlinux_epoch in s3 artifact manifest an integer](https://github.com/gardenlinux/python-gardenlinux-lib/commit/a8d9becea16e45aee10d964fad55f2806240f891)

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/commit/09ea136d8720a557381fb586431d19e5919d1b54 and https://github.com/gardenlinux/python-gardenlinux-lib/commit/a7545af15d3a1fa96675b24807eace643483da96 introduced a breaking change that breaks GLCI.