### PR TITLE
make suffix in s3 artifact manifest not contain cname

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.2
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.3
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.2
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.3
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
     version:
         description: GardenLinux Python library version
-        default: "0.8.2"
+        default: "0.8.3"
 runs:
     using: composite
     steps:

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -169,11 +169,18 @@ class S3Artifacts(object):
                 md5sum = file_digest(fp, "md5").hexdigest()
                 sha256sum = file_digest(fp, "sha256").hexdigest()
 
+            if artifact.name.startswith(cname):
+                suffix = artifact.name[len(cname) :]
+            else:
+                raise RuntimeError(
+                    f"Artifact name '{artifact.name}' does not start with cname '{cname}'"
+                )
+
             artifact_metadata = {
                 "name": artifact.name,
                 "s3_bucket_name": self._bucket.name,
                 "s3_key": s3_key,
-                "suffix": "".join(artifact.suffixes),
+                "suffix": suffix,
                 "md5sum": md5sum,
                 "sha256sum": sha256sum,
             }


### PR DESCRIPTION
**What this PR does / why we need it**:

make suffix in s3 artifact manifest not contain cname

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/commit/09ea136d8720a557381fb586431d19e5919d1b54 and https://github.com/gardenlinux/python-gardenlinux-lib/commit/a7545af15d3a1fa96675b24807eace643483da96 introduced a breaking change that breaks GLCI.