### PR TITLE
Fix `Layer.lookup_media_type_for_file_name()` to match file names as well

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.4
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.5
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.4
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.8.5
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Installs the given GardenLinux Python library
 inputs:
     version:
         description: GardenLinux Python library version
-        default: "0.8.4"
+        default: "0.8.5"
 runs:
     using: composite
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gardenlinux"
-version = "0.8.4"
+version = "0.8.5"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/gardenlinux/oci/layer.py
+++ b/src/gardenlinux/oci/layer.py
@@ -159,7 +159,7 @@ class Layer(_Layer, Mapping):
     @staticmethod
     def lookup_media_type_for_file_name(file_name: str) -> str:
         """
-        Looks up the media type based on file extension.
+        Looks up the media type based on file name or extension.
 
         :param file_name: File path and name of the target layer
 
@@ -170,9 +170,9 @@ class Layer(_Layer, Mapping):
         if not isinstance(file_name, PathLike):
             file_name = Path(file_name)
 
-        for suffix in GL_MEDIA_TYPES:
-            if file_name.match(f"*.{suffix}"):
-                return GL_MEDIA_TYPE_LOOKUP[suffix]
+        for lookup_name in GL_MEDIA_TYPES:
+            if file_name.match(f"*.{lookup_name}") or str(file_name) == lookup_name:
+                return GL_MEDIA_TYPE_LOOKUP[lookup_name]
 
         raise ValueError(
             f"Media type for {file_name} is not defined. You may want to add the definition to parse_features_lib"


### PR DESCRIPTION
**What this PR does / why we need it**:
After #146 being merged the logic to match against file extensions fail because the lookup list does contain full file names as well. This PR allows the media-type lookup to succeed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/3201