### PR TITLE
Apply Fix to Layer class methods correctly

### DIFF
--- a/src/gardenlinux/oci/layer.py
+++ b/src/gardenlinux/oci/layer.py
@@ -74,10 +74,10 @@ class Layer(_Layer, Mapping):
 
         if key == "annotations":
             self._annotations.clear()
-
-        raise KeyError(
-            f"'{self.__class__.__name__}' object is not subscriptable except for keys: {_SUPPORTED_MAPPING_KEYS}"
-        )
+        else:
+            raise KeyError(
+                f"'{self.__class__.__name__}' object is not subscriptable except for keys: {_SUPPORTED_MAPPING_KEYS}"
+            )
 
     def __getitem__(self, key):
         """
@@ -91,10 +91,10 @@ class Layer(_Layer, Mapping):
 
         if key == "annotations":
             return self._annotations
-        else:
-            raise KeyError(
-                f"'{self.__class__.__name__}' object is not subscriptable except for keys: {_SUPPORTED_MAPPING_KEYS}"
-            )
+
+        raise KeyError(
+            f"'{self.__class__.__name__}' object is not subscriptable except for keys: {_SUPPORTED_MAPPING_KEYS}"
+        )
 
     def __iter__(self):
         """


### PR DESCRIPTION
**What this PR does / why we need it**:

Places the `else` block in `__delitem__()` properly instead of `__getitem__()`

**Which issue(s) this PR fixes**:
Fixes n/A

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
bugfix developer
* Fix misplaced else block in __getitem__() and moves it to __delitem__() to fix always raising KeyError
```
