### PR TITLE
CI/Lint: Add pyright and isort to the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ format: install-dev
 
 lint: install-dev
 	$(POETRY) run black --check --extend-exclude test-data/gardenlinux .
+	$(POETRY) run isort --check-only --skip test-data/gardenlinux .
+	$(POETRY) run pyright
 
 security: install-dev
 	@if [ "$(CI)" = "true" ]; then \

--- a/poetry.lock
+++ b/poetry.lock
@@ -389,7 +389,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "platform_system == \"Windows\" or sys_platform == \"win32\"", docs = "sys_platform == \"win32\""}
+markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\" or platform_system == \"Windows\"", docs = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coverage"
@@ -636,6 +636,22 @@ files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
 ]
+
+[[package]]
+name = "isort"
+version = "6.0.1"
+description = "A Python utility / library to sort Python imports."
+optional = false
+python-versions = ">=3.9.0"
+groups = ["dev"]
+files = [
+    {file = "isort-6.0.1-py3-none-any.whl", hash = "sha256:2dc5d7f65c9678d94c88dfc29161a320eec67328bc97aad576874cb4be1e9615"},
+    {file = "isort-6.0.1.tar.gz", hash = "sha256:1cb5df28dfbc742e490c5e41bad6da41b805b0a8be7bc93cd0fb2a8a890ac450"},
+]
+
+[package.extras]
+colors = ["colorama"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jinja2"
@@ -892,6 +908,18 @@ test = ["pytest (>=7.2)", "pytest-cov (>=4.0)", "pytest-xdist (>=3.0)"]
 test-extras = ["pytest-mpl", "pytest-randomly"]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+groups = ["dev"]
+files = [
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
 name = "oras"
 version = "0.2.37"
 description = "OCI Registry as Storage Python SDK"
@@ -1012,6 +1040,27 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyright"
+version = "1.1.403"
+description = "Command line wrapper for pyright"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3"},
+    {file = "pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104"},
+]
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
+
+[package.extras]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -1657,6 +1706,18 @@ files = [
 pbr = ">=2.0.0"
 
 [[package]]
+name = "typing-extensions"
+version = "4.14.1"
+description = "Backported and Experimental Type Hints for Python 3.9+"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"},
+    {file = "typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1707,4 +1768,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "f963bf24286f21e81677ff349af27c4bbece4f99f65f15d3846674ccc92996ae"
+content-hash = "4b415a4a2297a7ee84bea343d5f1c4d95d4c68b5a7823388b6449c3771b10790"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ black = "^25.1.0"
 moto = "^5.1.9"
 pytest = "^8.4.1"
 pytest-cov = "^6.2.1"
+isort = "^6.0.1"
+pyright = "^1.1.403"
 
 [tool.poetry.group.docs.dependencies]
 sphinx-rtd-theme = "^3.0.2"
@@ -42,6 +44,17 @@ gl-s3 = "gardenlinux.s3.__main__:main"
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 norecursedirs = "test-data"
+
+[tool.isort]
+profile = "black"
+line_length = 120
+known_first_party = ["gardenlinux"]
+
+[tool.pyright]
+typeCheckingMode = "strict"
+venvPath = "."
+venv = ".venv"
+exclude = ["test-data", "docs", "hack", ".venv", ".pytest-cache", "**/__pycache"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,27 @@
+{
+    // Pyright is configured in 'strict' mode in pyproject.toml
+    // This file overrides some reports and tones them down to warnings, if they are not critical.
+    // It also turns some up to become warnings or errors.
+    "reportShadowedImports": "warning",
+    "reportImportCycles": "error",
+    "reportOptionalMemberAccess": "warning",
+    "reportOptionalSubscript": "warning",
+    "reportOptionalContextManager": "warning",
+    "reportOptionalCall": "warning",
+    "reportUnusedVariable": "warning",
+    "reportUnusedImport": "warning",
+    "reportUnusedFunction": "warning",
+    "reportUnusedCallResult": "warning",
+    "reportUnusedClass": "warning",
+    "reportUnnecessaryCast": "warning",
+    "reportUnnecessaryComparison": "warning",
+    "reportUnnecessaryIsInstance": "warning",
+    "reportUnnecessaryContains": "warning",
+    // Becomes useful after introduction of type annotations
+    // "reportUnknownMemberType": "warning",
+    // "reportUnknownParameterType": "warning",
+    // "reportUnknownArgumentType": "warning",
+    // "reportUnknownVariableType": "warning",
+    "reportTypedDictNotRequiredAccess": "error",
+    "reportDeprecated": "warning",
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

To improve general code quality (and also safety) this PR adds `pyright` and `isort` to the project for linting and import sorting respectively.

It will also gradually address all the `errors` the `pyright` linter finds in accordance to it's `pyrightconfig.json` and its [strict mode rules](https://microsoft.github.io/pyright/#/configuration?id=diagnostic-settings-defaults)

To not make it too noisy, I downgraded some of its default `errors` down to `warnings` if they are non-critical edge-cases or more style related than functional.

Another goal is to gradually add proper type annotations to the codebase in future PRs.

**Which issue(s) this PR fixes**:
Fixes #152 
