### PR TITLE
write_to_release_id_file

### DIFF
--- a/src/gardenlinux/constants.py
+++ b/src/gardenlinux/constants.py
@@ -145,3 +145,5 @@ GL_REPOSITORY_URL = "https://github.com/gardenlinux/gardenlinux"
 OCI_ANNOTATION_SIGNATURE_KEY = "io.gardenlinux.oci.signature"
 OCI_ANNOTATION_SIGNED_STRING_KEY = "io.gardenlinux.oci.signed-string"
 OCI_IMAGE_INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json"
+
+RELEASE_ID_FILE = ".github_release_id"

--- a/src/gardenlinux/github/release/__init__.py
+++ b/src/gardenlinux/github/release/__init__.py
@@ -1,8 +1,10 @@
 import json
 import os
+import sys
 
 import requests
 
+from gardenlinux.constants import RELEASE_ID_FILE
 from gardenlinux.logger import LoggerSetup
 
 LOGGER = LoggerSetup.get_logger("gardenlinux.github", "INFO")
@@ -45,6 +47,16 @@ def create_github_release(owner, repo, tag, commitish, latest, body):
         LOGGER.error("Failed to create release")
         LOGGER.debug(response.json())
         response.raise_for_status()
+
+
+def write_to_release_id_file(release_id):
+    try:
+        with open(RELEASE_ID_FILE, "w") as file:
+            file.write(release_id)
+        LOGGER.info(f"Created {RELEASE_ID_FILE} successfully.")
+    except IOError as e:
+        LOGGER.error(f"Could not create {RELEASE_ID_FILE} file: {e}")
+        sys.exit(1)
 
 
 def upload_to_github_release_page(

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -27,4 +27,6 @@ TEST_VERSION_STABLE = "1000"
 TEST_GARDENLINUX_RELEASE = "1877.3"
 TEST_GARDENLINUX_COMMIT = "75df9f401a842914563f312899ec3ce34b24515c"
 
+RELEASE_ID_FILE = ".github_release_id"
+
 S3_DOWNLOADS_DIR = Path(os.path.dirname(__file__)) / ".." / "s3_downloads"

--- a/tests/github/conftest.py
+++ b/tests/github/conftest.py
@@ -1,9 +1,10 @@
 import os
 import shutil
+from pathlib import Path
 
 import pytest
 
-from ..constants import S3_DOWNLOADS_DIR
+from ..constants import RELEASE_ID_FILE, S3_DOWNLOADS_DIR
 
 
 @pytest.fixture
@@ -26,3 +27,10 @@ def artifact_for_upload(downloads_dir):
     artifact.touch()
     yield artifact
     artifact.unlink()
+
+
+@pytest.fixture
+def release_id_file():
+    f = Path(RELEASE_ID_FILE)
+    yield f
+    f.unlink()

--- a/tests/github/test_create_github_release.py
+++ b/tests/github/test_create_github_release.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 import requests_mock
 
-from gardenlinux.github.release import create_github_release
+from gardenlinux.github.release import create_github_release, write_to_release_id_file
 
 from ..constants import TEST_GARDENLINUX_COMMIT, TEST_GARDENLINUX_RELEASE
 
@@ -54,3 +54,16 @@ def test_create_github_release(caplog, github_token):
             False,
             "") == 101
         assert any("Release created successfully" in record.message for record in caplog.records), "Expected a success log record"
+
+
+def test_write_to_release_id_file(release_id_file):
+    write_to_release_id_file(TEST_GARDENLINUX_RELEASE)
+    assert release_id_file.read_text() == TEST_GARDENLINUX_RELEASE
+
+
+def test_write_to_release_id_file_broken_file_permissions(release_id_file, caplog):
+    release_id_file.touch(0)  # this will make the file unwritable
+
+    with pytest.raises(SystemExit):
+        write_to_release_id_file(TEST_GARDENLINUX_RELEASE)
+    assert any("Could not create" in record.message for record in caplog.records), "Expected a failure log record"


### PR DESCRIPTION
**What this PR does / why we need it**:
Splitting https://github.com/gardenlinux/python-gardenlinux-lib/pull/179 into smaller parts

**Which issue(s) this PR fixes**:
https://github.com/gardenlinux/gardenlinux/issues/3054
