### PR TITLE
Typing: Fix pyright type issues in apt module

### DIFF
--- a/src/gardenlinux/apt/debsource.py
+++ b/src/gardenlinux/apt/debsource.py
@@ -106,7 +106,7 @@ class DebsrcFile(dict[str, Debsrc]):
 
         self._set_source(parsed_source, parsed_version)
 
-    def _set_source(self, source: str, version: str) -> None:
+    def _set_source(self, source: str | None, version: str | None) -> None:
         """
         Sets the dict value based on the given source key.
 

--- a/src/gardenlinux/apt/package_repo_info.py
+++ b/src/gardenlinux/apt/package_repo_info.py
@@ -71,7 +71,7 @@ class GardenLinuxRepo(APTRepository):
 
 def compare_gardenlinux_repo_version(
     version_a: str, version_b: str
-) -> list[tuple[str, str, str]]:
+) -> list[tuple[str, str | None, str | None]]:
     """
     Compares differences between repository versions given.
 
@@ -89,7 +89,7 @@ def compare_gardenlinux_repo_version(
 
 def compare_repo(
     a: GardenLinuxRepo, b: GardenLinuxRepo, available_in_both: Optional[bool] = False
-) -> list[tuple[str, str, str]]:
+) -> list[tuple[str, str | None, str | None]]:
     """
     Compares differences between repositories given.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is the first of a series that fixes all issues raised by `pyright`.
In this case, it fixes smaller typing issues within the `apt` module that are caused by inaccurate function signatures not reflecting possible `None` values.

It does not change the underlying logic, but adjusts the function signatures to reflect the types correctly.

**Which issue(s) this PR fixes**:
Tracks #152 
