### PR TITLE
Linting: Fix type errors in git module

### DIFF
--- a/src/gardenlinux/git/repository.py
+++ b/src/gardenlinux/git/repository.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import sys
 from os import PathLike
 from pathlib import Path
 
@@ -25,7 +24,7 @@ class Repository(_Repository):
                  Apache License, Version 2.0
     """
 
-    def __init__(self, git_directory=".", logger=None, **kwargs):
+    def __init__(self, git_directory: str | PathLike[str] = ".", logger=None, **kwargs):
         """
         Constructor __init__(Repository)
 
@@ -38,8 +37,7 @@ class Repository(_Repository):
         if logger is None or not logger.hasHandlers():
             logger = LoggerSetup.get_logger("gardenlinux.git")
 
-        if not isinstance(git_directory, PathLike):
-            git_directory = Path(git_directory)
+        git_directory = Path(git_directory)
 
         if not git_directory.exists():
             raise RuntimeError(f"Git directory given is invalid: {git_directory}")
@@ -107,11 +105,11 @@ class Repository(_Repository):
 
     @staticmethod
     def checkout_repo(
-        git_directory,
+        git_directory: str | PathLike[str],
         repo_url=GL_REPOSITORY_URL,
-        branch="main",
-        commit=None,
-        pathspecs=None,
+        branch: str = "main",
+        commit: str | None = None,
+        pathspecs: list[str] | None = None,
         logger=None,
         **kwargs,
     ):
@@ -122,8 +120,7 @@ class Repository(_Repository):
         :since:  0.10.0
         """
 
-        if not isinstance(git_directory, PathLike):
-            git_directory = Path(git_directory)
+        git_directory = Path(git_directory)
 
         if not git_directory.is_dir() or git_directory.match("/*"):
             raise RuntimeError(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR addresses some issues with potentially invalid function calls in the `git` module.
The issue arose from a post-fact check if the given `git_directory` parameter was an instance of `PathLike` , raising an error if not and then going ahead and calling `pathlib` specific function like `exists()` on the parameter. `git_directory` remained typed as `str | PathLike` though.

This led to calls to `pathlib.Path`-specific methods such as `.exists()`, `.is_dir()`, and `.match()` on values that Pyright could not guarantee were Path instances.

This PR changes that behavior to always explicitly cast `git_directory` into a `Path` object; eliminating the need for the type checks.

**Which issue(s) this PR fixes**:
Tracks #152 
