### PR TITLE
Lint: Fix pyright errors in `s3` module

### DIFF
--- a/src/gardenlinux/s3/__main__.py
+++ b/src/gardenlinux/s3/__main__.py
@@ -6,12 +6,6 @@ gl-s3 main entrypoint
 """
 
 import argparse
-import os
-import re
-import sys
-from functools import reduce
-from pathlib import Path
-from typing import Any, List, Set
 
 from .s3_artifacts import S3Artifacts
 

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -192,6 +192,18 @@ class S3Artifacts(object):
             "paths": [],
         }
 
+        # Catch any invalid artifacts
+        bad_files = [
+            f
+            for f in artifacts_dir.iterdir()
+            if not f.name.startswith(cname)
+            and f.suffix not in [".release", ".requirements"]
+        ]
+        if bad_files:
+            raise RuntimeError(
+                f"Artifact name '{bad_files[0].name}' does not start with cname '{cname}'"
+            )
+
         for artifact in artifacts_dir.iterdir():
             if not artifact.match(f"{cname}*"):
                 continue

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -18,7 +18,6 @@ from urllib.parse import urlencode
 import yaml
 
 from ..features.cname import CName
-from ..logger import LoggerSetup
 from .bucket import Bucket
 
 
@@ -53,7 +52,7 @@ class S3Artifacts(object):
         :since: 0.8.0
         """
 
-        self._bucket = Bucket(bucket_name, endpoint_url, s3_resource_config)
+        self._bucket = Bucket(bucket_name, endpoint_url, s3_resource_config, logger)
 
     @property
     def bucket(self):
@@ -68,8 +67,8 @@ class S3Artifacts(object):
 
     def download_to_directory(
         self,
-        cname,
-        artifacts_dir,
+        cname: str,
+        artifacts_dir: str | PathLike[str],
     ):
         """
         Download S3 artifacts to a given directory.
@@ -80,8 +79,7 @@ class S3Artifacts(object):
         :since: 0.8.0
         """
 
-        if not isinstance(artifacts_dir, PathLike):
-            artifacts_dir = Path(artifacts_dir)
+        artifacts_dir = Path(artifacts_dir)
 
         if not artifacts_dir.is_dir():
             raise RuntimeError(f"Artifacts directory given is invalid: {artifacts_dir}")
@@ -101,8 +99,8 @@ class S3Artifacts(object):
 
     def upload_from_directory(
         self,
-        cname,
-        artifacts_dir,
+        cname: str,
+        artifacts_dir: str | PathLike[str],
         delete_before_push=False,
     ):
         """
@@ -115,8 +113,7 @@ class S3Artifacts(object):
         :since: 0.8.0
         """
 
-        if not isinstance(artifacts_dir, PathLike):
-            artifacts_dir = Path(artifacts_dir)
+        artifacts_dir = Path(artifacts_dir)
 
         cname_object = CName(cname)
 
@@ -145,6 +142,9 @@ class S3Artifacts(object):
             raise RuntimeError(
                 f"Release file data and given cname conflict detected: Commit ID {cname_object.commit_id}"
             )
+
+        if cname_object.version is None:
+            raise RuntimeError("CName version could not be determined!")
 
         commit_hash = release_config.get(UNNAMED_SECTION, "GARDENLINUX_COMMIT_ID_LONG")
 

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -143,9 +143,6 @@ class S3Artifacts(object):
                 f"Release file data and given cname conflict detected: Commit ID {cname_object.commit_id}"
             )
 
-        if cname_object.version is None:
-            raise RuntimeError("CName version could not be determined!")
-
         commit_hash = release_config.get(UNNAMED_SECTION, "GARDENLINUX_COMMIT_ID_LONG")
 
         feature_set = release_config.get(UNNAMED_SECTION, "GARDENLINUX_FEATURES")

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -196,18 +196,18 @@ class S3Artifacts(object):
             if not artifact.match(f"{cname}*"):
                 continue
 
+            if not artifact.name.startswith(cname):
+                raise RuntimeError(
+                    f"Artifact name '{artifact.name}' does not start with cname '{cname}'"
+                )
+
             s3_key = f"objects/{cname}/{artifact.name}"
 
             with artifact.open("rb") as fp:
                 md5sum = file_digest(fp, "md5").hexdigest()
                 sha256sum = file_digest(fp, "sha256").hexdigest()
 
-            if artifact.name.startswith(cname):
-                suffix = artifact.name[len(cname) :]
-            else:
-                raise RuntimeError(
-                    f"Artifact name '{artifact.name}' does not start with cname '{cname}'"
-                )
+            suffix = artifact.name[len(cname) :]
 
             artifact_metadata = {
                 "name": artifact.name,

--- a/tests/s3/test_bucket.py
+++ b/tests/s3/test_bucket.py
@@ -8,13 +8,19 @@ A mock AWS environment is provided by the `s3_setup` fixture found in `conftest.
 """
 
 import io
-from pathlib import Path
-
-import pytest
 
 from gardenlinux.s3.bucket import Bucket
 
 REGION = "us-east-1"
+
+
+def test_bucket_minimal(s3_setup):
+    """
+    Ensure Bucket initializes correctly.
+    """
+    env = s3_setup
+    bucket = Bucket(env.bucket_name)
+    assert bucket.name == env.bucket_name
 
 
 def test_objects_empty(s3_setup):

--- a/tests/s3/test_s3_artifacts.py
+++ b/tests/s3/test_s3_artifacts.py
@@ -260,6 +260,8 @@ def test_upload_from_directory_commit_mismatch_raises(s3_setup):
     bad_data = RELEASE_DATA.replace("abc123", "wrong")
     release_path.write_text(bad_data)
     artifacts = S3Artifacts(env.bucket_name)
+
+    # Act / Assert
     with pytest.raises(RuntimeError, match="Commit ID"):
         artifacts.upload_from_directory(env.cname, env.tmp_path)
 

--- a/tests/s3/test_s3_artifacts.py
+++ b/tests/s3/test_s3_artifacts.py
@@ -212,6 +212,8 @@ def test_upload_from_directory_none_version_raises(monkeypatch, s3_setup):
 
     import gardenlinux.s3.s3_artifacts as s3art
 
+    # Monkeypatch CName to force Cname.version to be None and avoid
+    # class internal error checks
     class DummyCName:
         arch = "amd64"
         version = None


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes mainly typing issues in the `s3` module, mainly by explicitly casting or typing as Noneable.

**Which issue(s) this PR fixes**:
Tracks #152 