### PR TITLE
Revert "Tests: Properly catch all invalid artifacts"

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.0
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.3
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.0
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.3
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: Installs the given GardenLinux Python library
 inputs:
   version:
     description: GardenLinux Python library version
-    default: "0.10.2"
+    default: "0.10.3"
   python_version:
     description: Python version to setup
     default: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gardenlinux"
-version = "0.10.2"
+version = "0.10.3"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -189,18 +189,6 @@ class S3Artifacts(object):
             "paths": [],
         }
 
-        # Catch any invalid artifacts
-        bad_files = [
-            f
-            for f in artifacts_dir.iterdir()
-            if not f.name.startswith(cname)
-            and f.suffix not in [".release", ".requirements"]
-        ]
-        if bad_files:
-            raise RuntimeError(
-                f"Artifact name '{bad_files[0].name}' does not start with cname '{cname}'"
-            )
-
         for artifact in artifacts_dir.iterdir():
             if not artifact.match(f"{cname}*"):
                 continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR restores previous behavior to tolerate not "cname" prefixed files in a directory to be uploaded using `gh-s3` utility.

**Which issue(s) this PR fixes**:
Fixes issue seen in run https://github.com/gardenlinux/gardenlinux/actions/runs/18756655543

**Special notes for your reviewer**:
This reverts commit cf80d58615334bfa165353439fa10613a00fa54b.