### PR TITLE
Encode certain special characters of AWS S3 tags as `+`

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.3
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.4
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.3
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.4
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: Installs the given GardenLinux Python library
 inputs:
   version:
     description: GardenLinux Python library version
-    default: "0.10.3"
+    default: "0.10.4"
   python_version:
     description: Python version to setup
     default: "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gardenlinux"
-version = "0.10.3"
+version = "0.10.4"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -5,6 +5,7 @@ S3 GardenLinux artifacts
 """
 
 import logging
+import re
 from configparser import UNNAMED_SECTION, ConfigParser
 from datetime import datetime
 from hashlib import file_digest
@@ -189,6 +190,8 @@ class S3Artifacts(object):
             "paths": [],
         }
 
+        re_object = re.compile("[^a-zA-Z0-9\\s+\\-=.\\_:/@]")
+
         for artifact in artifacts_dir.iterdir():
             if not artifact.match(f"{cname}*"):
                 continue
@@ -216,9 +219,9 @@ class S3Artifacts(object):
             }
 
             s3_tags = {
-                "architecture": cname_object.arch,
-                "platform": cname_object.platform,
-                "version": cname_object.version,
+                "architecture": re_object.sub("+", cname_object.arch),
+                "platform": re_object.sub("+", cname_object.platform),
+                "version": re_object.sub("+", cname_object.version),
                 "committish": commit_hash,
                 "md5sum": md5sum,
                 "sha256sum": sha256sum,

--- a/tests/s3/conftest.py
+++ b/tests/s3/conftest.py
@@ -22,7 +22,7 @@ class S3Env:
 
 
 def make_cname(
-    flavor: str = "container",
+    flavor: str = "kvm-container",
     arch: str = "amd64",
     version: str = "1234.1",
     commit: str = "abc123",

--- a/tests/s3/test_s3_artifacts.py
+++ b/tests/s3/test_s3_artifacts.py
@@ -120,6 +120,10 @@ def test_upload_from_directory_success(s3_setup):
     assert metadata["require_uefi"] is True
     assert metadata["secureboot"] is True
 
+    raw_tags_response = env.s3.meta.client.get_object_tagging(Bucket=env.bucket_name, Key=f"objects/{env.cname}/{env.cname}-file1")
+    tags = { tag['Key']: tag['Value'] for tag in raw_tags_response["TagSet"] }
+    assert tags["platform"] == "container+kvm"
+
 
 def test_upload_from_directory_with_delete(s3_setup):
     """


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR ensures tags created at AWS buckets do not contain characters [not supported](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions) by the cloud provider.

**Which issue(s) this PR fixes**:
Related https://github.com/gardenlinux/gardenlinux/issues/3720