### PR TITLE
feat: decouple S3 upload from features directory

### DIFF
--- a/src/gardenlinux/s3/__main__.py
+++ b/src/gardenlinux/s3/__main__.py
@@ -27,6 +27,7 @@ def main() -> None:
     parser.add_argument("--bucket", dest="bucket")
     parser.add_argument("--cname", required=False, dest="cname")
     parser.add_argument("--path", required=False, dest="path")
+    parser.add_argument("--dry-run", action="store_true")
 
     parser.add_argument("action", nargs="?", choices=_ARGS_ACTION_ALLOWED)
 
@@ -35,4 +36,4 @@ def main() -> None:
     if args.action == "download-artifacts-from-bucket":
         S3Artifacts(args.bucket).download_to_directory(args.cname, args.path)
     elif args.action == "upload-artifacts-to-bucket":
-        S3Artifacts(args.bucket).upload_from_directory(args.cname, args.path)
+        S3Artifacts(args.bucket).upload_from_directory(args.cname, args.path, dry_run=args.dry_run)


### PR DESCRIPTION
uploading build artifacts should be trivially doable using _just_ the artifacts. no need to require the features directory which till no was implicitly required by using `cname_object = CName(cname)`

Besides simplifying the upload logic this is also crucially important if (as is currently the case in the main GL repo) the publish logic runs from the main branch, even when publishing artifacts from a `rel-X` branch, since there are zero guarantees that the features directory from the main branch will behave identical to the release branch for the same cname.