### PR TITLE
Ensure only files supported by GitHub actions are considered for `actions/setup-python`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,10 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
-
+        cache: ${{ steps.env-check.outputs.package_tool }}
+        cache-dependency-path: |
+          ${{ github.workspace }}/poetry.lock
+          ${{ github.workspace }}/requirements.txt
     - name: Install GardenLinux Python library
       shell: bash
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tunes `.github/actions/setup` to list only Python cache dependency files supported by the workflow itself.

**Which issue(s) this PR fixes**:
Fixes #255
Fixes https://github.com/gardenlinux/gardenlinux/issues/3882
Superseeds #256