### PR TITLE
disabled python setup cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -46,7 +46,6 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python_version }}
-        cache: ${{ steps.env-check.outputs.package_tool }}
 
     - name: Install GardenLinux Python library
       shell: bash


### PR DESCRIPTION
**What this PR does / why we need it**:

To confirm the actual status quo in the GL workflows that use a hotfix branch already. This is needed for 0.10.6 to be used without issues.