### PR TITLE
Update and consistently pin all github actions

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f805dacd2a1e0feb41950f5bc311bd174639ad4f # 0.10.7
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f805dacd2a1e0feb41950f5bc311bd174639ad4f # 0.10.7
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -40,10 +40,10 @@ runs:
 
     - name: Install Poetry
       if: steps.env-check.outputs.package_tool == 'poetry'
-      uses: snok/install-poetry@v1
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
 
     - name: Set up Python ${{ inputs.python_version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       with:
         python-version: ${{ inputs.python_version }}
         cache: ${{ steps.env-check.outputs.package_tool }}

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/setup
       - name: Simple bandit security checks
         run: make security

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,6 +6,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/setup
       - run: make lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/setup
       - name: Simple poetry build no package
         run: make build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - uses: ./.github/actions/setup
       - run: make docs
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages

--- a/.github/workflows/pytests.yml
+++ b/.github/workflows/pytests.yml
@@ -15,7 +15,7 @@ jobs:
         python_version: ["3.13"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 2
 
@@ -39,6 +39,6 @@ jobs:
         run: test -f coverage.xml
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Follow up for https://github.com/gardenlinux/gardenlinux/pull/4015


Needed to avoid this error

```
Error: The actions actions/setup-python@v5 and snok/install-poetry@v1 are not allowed in gardenlinux/gardenlinux because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: aws-actions/configure-aws-credentials@*, azure/k8s-set-context@v*, azure/login@*, codecov/codecov-action@*, docker/setup-qemu-action@*, gardenlinux/*, gardenlinux/workflow-telemetry-action@*, golangci/golangci-lint-action@*, google-github-actions/auth@*, jdx/mise-action@*, opentofu/setup-opentofu@*, oras-project/setup-oras@*, peaceiris/actions-gh-pages@*, peaceiris/actions-gh-pages@v3, pmeier/pytest-results-action@*, psf/black@stable, redhat-plumbers-in-action/differential-shellcheck@*, snok/install-poetry@*, softprops/action-gh-release@v2, toanju/package-build/*. All actions must also be pinned to a full-length commit SHA.
```