### PR TITLE
CI: Pin all workflows to 0.10.8 commit hash

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -2,16 +2,16 @@ name: features_parse
 description: Parses the given GardenLinux features parameters
 inputs:
   flags:
-    description: 'Flags passed to `gl-features-parse`'
+    description: "Flags passed to `gl-features-parse`"
     required: true
 outputs:
   result:
-    description: 'features result'
+    description: "features result"
     value: ${{ steps.result.outputs.result }}
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f805dacd2a1e0feb41950f5bc311bd174639ad4f # 0.10.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@124bed686e26b2014e89f4359b67cde59bc66e03 # 0.10.8
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -2,18 +2,18 @@ name: flavors_parse
 description: Parses the given GardenLinux flavors parameters
 inputs:
   flags:
-    description: 'Flags passed to `gl-flavors-parse`'
+    description: "Flags passed to `gl-flavors-parse`"
     required: true
   flavors_matrix:
-    description: 'Generated GitHub workflow flavors matrix'
+    description: "Generated GitHub workflow flavors matrix"
 outputs:
   matrix:
-    description: 'Flavors matrix'
+    description: "Flavors matrix"
     value: ${{ steps.matrix.outputs.matrix }}
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@f805dacd2a1e0feb41950f5bc311bd174639ad4f # 0.10.7
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@124bed686e26b2014e89f4359b67cde59bc66e03 # 0.10.8
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: Installs the given GardenLinux Python library
 inputs:
   version:
     description: GardenLinux Python library version
-    default: "0.10.7"
+    default: "0.10.8"
   python_version:
     description: Python version to setup
     default: "3.13"


### PR DESCRIPTION
**What this PR does / why we need it**:

Update workflows to pin against latest tag's commit.

**Which issue(s) this PR fixes**:
Fixes n/A
