### PR TITLE
fix: use local setup workflow for composite actions

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@124bed686e26b2014e89f4359b67cde59bc66e03 # 0.10.8
+    - uses: ./.github/actions/setup
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@124bed686e26b2014e89f4359b67cde59bc66e03 # 0.10.8
+    - uses: ./.github/actions/setup
     - id: matrix
       shell: bash
       run: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Use local setup workflow for composite actions. This should solve the issue of self-referencing the workflow.
