### PR TITLE
Add support to add tags to OCI image indices

### DIFF
--- a/.github/actions/features_parse/action.yml
+++ b/.github/actions/features_parse/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.8
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.9
     - id: result
       shell: bash
       run: |

--- a/.github/actions/flavors_parse/action.yml
+++ b/.github/actions/flavors_parse/action.yml
@@ -13,7 +13,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.8
+    - uses: gardenlinux/python-gardenlinux-lib/.github/actions/setup@0.10.9
     - id: matrix
       shell: bash
       run: |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ description: Installs the given GardenLinux Python library
 inputs:
   version:
     description: GardenLinux Python library version
-    default: "0.10.8"
+    default: "0.10.9"
   python_version:
     description: Python version to setup
     default: "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gardenlinux"
-version = "0.10.8"
+version = "0.10.9"
 description = "Contains tools to work with the features directory of gardenlinux, for example deducting dependencies from feature sets or validating cnames"
 authors = ["Garden Linux Maintainers <contact@gardenlinux.io>"]
 license = "Apache-2.0"

--- a/src/gardenlinux/oci/__main__.py
+++ b/src/gardenlinux/oci/__main__.py
@@ -25,6 +25,85 @@ def cli() -> None:
 
 @cli.command()
 @click.option(
+    "--index",
+    required=True,
+    help="OCI image index",
+)
+@click.option(
+    "--index-tag",
+    required=True,
+    help="OCI image index tag",
+)
+@click.option(
+    "--manifest_folder",
+    default="manifests",
+    help="A folder where the index entries are read from.",
+)
+@click.option(
+    "--insecure",
+    default=False,
+    help="Use HTTP to communicate with the registry",
+)
+@click.option(
+    "--additional_tag",
+    required=False,
+    multiple=True,
+    help="Additional tag to push the index with",
+)
+def push_index_from_directory(
+    index: str,
+    index_tag: str,
+    manifest_folder: str,
+    insecure: bool,
+    additional_tag: List[str],
+) -> None:
+    """
+    Push a list of files from the `manifest_folder` to an index.
+
+    :since: 0.10.9
+    """
+
+    index = Container(f"{index}:{index_tag}", insecure=insecure)
+    index.push_index_from_directory(manifest_folder, additional_tag)
+
+
+@cli.command()
+@click.option(
+    "--index",
+    required=True,
+    help="OCI image index",
+)
+@click.option(
+    "--index-tag",
+    required=True,
+    help="OCI image index tag",
+)
+@click.option(
+    "--insecure",
+    default=False,
+    help="Use HTTP to communicate with the registry",
+)
+@click.option(
+    "--tag",
+    required=True,
+    multiple=True,
+    help="Tag to push the OCI image index with",
+)
+def push_index_tags(index: str, index_tag: str, insecure: bool, tag: List[str]) -> None:
+    """
+    Push OCI image index tags to a registry.
+
+    :since: 0.10.9
+    """
+
+    index = Container(f"{index}:{index_tag}", insecure=insecure)
+
+    image_index = index.read_or_generate_index()
+    index.push_index_for_tags(image_index, tag)
+
+
+@cli.command()
+@click.option(
     "--container",
     required=True,
     type=click.Path(),
@@ -94,10 +173,7 @@ def push_manifest(
     :since: 0.7.0
     """
 
-    container = Container(
-        f"{container}:{version}",
-        insecure=insecure,
-    )
+    container = Container(f"{container}:{version}", insecure=insecure)
 
     manifest = container.read_or_generate_manifest(cname, arch, version, commit)
 
@@ -173,65 +249,10 @@ def push_manifest_tags(
     :since: 0.10.0
     """
 
-    container = Container(
-        f"{container}:{version}",
-        insecure=insecure,
-    )
+    container = Container(f"{container}:{version}", insecure=insecure)
 
     manifest = container.read_or_generate_manifest(cname, arch, version, commit)
     container.push_manifest_for_tags(manifest, tag)
-
-
-@cli.command()
-@click.option(
-    "--container",
-    "container",
-    required=True,
-    type=click.Path(),
-    help="Container Name",
-)
-@click.option(
-    "--version",
-    "version",
-    required=True,
-    type=click.Path(),
-    help="Version of image",
-)
-@click.option(
-    "--manifest_folder",
-    default="manifests",
-    help="A folder where the index entries are read from.",
-)
-@click.option(
-    "--insecure",
-    default=False,
-    help="Use HTTP to communicate with the registry",
-)
-@click.option(
-    "--additional_tag",
-    required=False,
-    multiple=True,
-    help="Additional tag to push the index with",
-)
-def update_index(
-    container: str,
-    version: str,
-    manifest_folder: str,
-    insecure: bool,
-    additional_tag: List[str],
-) -> None:
-    """
-    Push a list of files from the `manifest_folder` to an index.
-
-    :since: 0.7.0
-    """
-
-    container = Container(
-        f"{container}:{version}",
-        insecure=insecure,
-    )
-
-    container.push_index_from_directory(manifest_folder, additional_tag)
 
 
 def main() -> None:

--- a/tests/oci/test_oci.py
+++ b/tests/oci/test_oci.py
@@ -121,10 +121,10 @@ def update_index(
     print("Updating index")
 
     cmd = [
-        "update-index",
-        "--container",
+        "push-index-from-directory",
+        "--index",
         CONTAINER_NAME_ZOT_EXAMPLE,
-        "--version",
+        "--index-tag",
         version,
         "--insecure",
         "True",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support to tag OCI image indices like for OCI image manifests. It further renames `update-index` to `push-index-from-directory` of `gl-oci`.

**Which issue(s) this PR fixes**:
Related https://github.com/gardenlinux/gardenlinux/issues/3943