### PR TITLE
Reuse and extend standardized OCI annotations

### DIFF
--- a/src/gardenlinux/oci/container.py
+++ b/src/gardenlinux/oci/container.py
@@ -319,7 +319,7 @@ class Container(Registry):  # type: ignore[misc]
         :since: 0.7.0
         """
 
-        # For each additional tag, push the manifest using Registry.upload_manifest
+        # For each additional tag, push the index using Registry.upload_index
         for tag in tags:
             self._check_200_response(self._upload_index(index, tag))
 
@@ -626,8 +626,21 @@ class Container(Registry):  # type: ignore[misc]
             f"{self.prefix}://{self.hostname}/v2/{self._container_name}/manifests/{reference}",
             "PUT",
             headers={"Content-Type": OCI_IMAGE_INDEX_MEDIA_TYPE},
-            data=index.json,
+            json=index.extended_dict,
         )
+
+    def upload_manifest(self, manifest: Manifest, container: OrasContainer) -> Response:
+        """
+        oras-project.github.io: Read a manifest file and upload it.
+
+        :param manifest:  manifest to upload
+        :param container: parsed container URI
+
+        :return: (object) OCI manifest put response
+        :since:  1.0.0
+        """
+
+        return Registry.upload_manifest(self, manifest.extended_dict, container)  # type: ignore[no-any-return]
 
     @staticmethod
     def get_artifacts_metadata_from_files(

--- a/src/gardenlinux/oci/index.py
+++ b/src/gardenlinux/oci/index.py
@@ -34,6 +34,17 @@ class Index(dict):  # type: ignore[type-arg]
         self.update(**kwargs)
 
     @property
+    def extended_dict(self) -> Dict[str, Any]:
+        """
+        Returns the final parsed and extended OCI image index dictionary
+
+        :return: (dict) OCI image index dictionary
+        :since:  1.0.0
+        """
+
+        return self.copy()
+
+    @property
     def json(self) -> bytes:
         """
         Returns the OCI image index as a JSON
@@ -42,7 +53,7 @@ class Index(dict):  # type: ignore[type-arg]
         :since:  0.7.0
         """
 
-        return json.dumps(self).encode("utf-8")
+        return json.dumps(self.extended_dict).encode("utf-8")
 
     @property
     def manifests_as_dict(self) -> Dict[str, Dict[str, Any]]:

--- a/src/gardenlinux/oci/layer.py
+++ b/src/gardenlinux/oci/layer.py
@@ -5,7 +5,6 @@ from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
-from oras.defaults import annotation_title as ANNOTATION_TITLE
 from oras.oci import Layer as _Layer
 
 from ..constants import GL_MEDIA_TYPE_LOOKUP, GL_MEDIA_TYPES
@@ -24,6 +23,15 @@ class Layer(_Layer, Mapping):  # type: ignore[misc, type-arg]
     :since:      0.7.0
     :license:    https://www.apache.org/licenses/LICENSE-2.0
                  Apache License, Version 2.0
+    """
+
+    ANNOTATION_ARCH_KEY = "io.gardenlinux.image.layer.architecture"
+    """
+    OCI image layer architecture annotation
+    """
+    ANNOTATION_TITLE_KEY = "org.opencontainers.image.title"
+    """
+    OCI image layer title annotation
     """
 
     def __init__(
@@ -48,7 +56,7 @@ class Layer(_Layer, Mapping):  # type: ignore[misc, type-arg]
         _Layer.__init__(self, blob_path, media_type, is_dir)
 
         self._annotations = {
-            ANNOTATION_TITLE: blob_path.name,  # type: ignore[attr-defined]
+            Layer.ANNOTATION_TITLE_KEY: blob_path.name,  # type: ignore[attr-defined]
         }
 
     @property
@@ -157,7 +165,7 @@ class Layer(_Layer, Mapping):  # type: ignore[misc, type-arg]
         return {
             "file_name": file_name.name,  # type: ignore[attr-defined]
             "media_type": media_type,
-            "annotations": {"io.gardenlinux.image.layer.architecture": arch},
+            "annotations": {Layer.ANNOTATION_ARCH_KEY: arch},
         }
 
     @staticmethod

--- a/src/gardenlinux/oci/manifest.py
+++ b/src/gardenlinux/oci/manifest.py
@@ -22,6 +22,15 @@ class Manifest(dict):  # type: ignore[type-arg]
                  Apache License, Version 2.0
     """
 
+    ANNOTATION_COMMIT_KEY = "commit"
+    """
+    OCI image manifest GardenLinux commit hash annotation
+    """
+    ANNOTATION_VERSION_KEY = "version"
+    """
+    OCI image manifest GardenLinux version annotation
+    """
+
     def __init__(self, *args: Any, **kwargs: Any):
         """
         Constructor __init__(Manifest)
@@ -46,12 +55,12 @@ class Manifest(dict):  # type: ignore[type-arg]
         :since:  0.7.0
         """
 
-        if "commit" not in self.get("annotations", {}):
+        if Manifest.ANNOTATION_COMMIT_KEY not in self.get("annotations", {}):
             raise RuntimeError(
-                "Unexpected manifest with missing config annotation 'commit' found"
+                f"Unexpected manifest with missing config annotation '{Manifest.ANNOTATION_COMMIT_KEY}' found"
             )
 
-        return self["annotations"]["commit"]  #  type: ignore[no-any-return]
+        return self["annotations"][Manifest.ANNOTATION_COMMIT_KEY]  #  type: ignore[no-any-return]
 
     @commit.setter
     def commit(self, value: str) -> None:
@@ -64,7 +73,7 @@ class Manifest(dict):  # type: ignore[type-arg]
         """
 
         self._ensure_annotations_dict()
-        self["annotations"]["commit"] = value
+        self["annotations"][Manifest.ANNOTATION_COMMIT_KEY] = value
 
     @property
     def config_json(self) -> bytes:
@@ -90,6 +99,18 @@ class Manifest(dict):  # type: ignore[type-arg]
         return f"sha256:{digest}"
 
     @property
+    def extended_dict(self) -> Dict[str, Any]:
+        """
+        Returns the final parsed and extended OCI manifest dictionary
+
+        :return: (dict) OCI manifest dictionary
+        :since:  1.0.0
+        """
+
+        self._ensure_annotations_dict()
+        return self.copy()
+
+    @property
     def json(self) -> bytes:
         """
         Returns the OCI image manifest as a JSON
@@ -98,7 +119,7 @@ class Manifest(dict):  # type: ignore[type-arg]
         :since:  0.7.0
         """
 
-        return json.dumps(self).encode("utf-8")
+        return json.dumps(self.extended_dict).encode("utf-8")
 
     @property
     def size(self) -> int:
@@ -120,12 +141,12 @@ class Manifest(dict):  # type: ignore[type-arg]
         :since:  0.7.0
         """
 
-        if "version" not in self.get("annotations", {}):
+        if Manifest.ANNOTATION_VERSION_KEY not in self.get("annotations", {}):
             raise RuntimeError(
-                "Unexpected manifest with missing config annotation 'version' found"
+                f"Unexpected manifest with missing config annotation '{Manifest.ANNOTATION_VERSION_KEY}' found"
             )
 
-        return self["annotations"]["version"]  # type: ignore[no-any-return]
+        return self["annotations"][Manifest.ANNOTATION_VERSION_KEY]  # type: ignore[no-any-return]
 
     @version.setter
     def version(self, value: str) -> None:
@@ -138,7 +159,7 @@ class Manifest(dict):  # type: ignore[type-arg]
         """
 
         self._ensure_annotations_dict()
-        self["annotations"]["version"] = value
+        self["annotations"][Manifest.ANNOTATION_VERSION_KEY] = value
 
     def config_from_dict(
         self, config: Dict[str, Any], annotations: Dict[str, Any]
@@ -166,5 +187,11 @@ class Manifest(dict):  # type: ignore[type-arg]
         self["config"] = config
 
     def _ensure_annotations_dict(self) -> None:
+        """
+        Ensure the annotations dictionary is initialized.
+
+        :since: 0.7.0
+        """
+
         if "annotations" not in self:
             self["annotations"] = {}

--- a/tests/oci/test_image_manifest.py
+++ b/tests/oci/test_image_manifest.py
@@ -8,7 +8,7 @@ from gardenlinux.oci import ImageManifest, Layer
 def test_ImageManifest_arch() -> None:
     # Arrange
     empty_manifest = ImageManifest()
-    manifest = ImageManifest(annotations={"architecture": "amd64"})
+    manifest = ImageManifest(annotations={ImageManifest.ANNOTATION_ARCH_KEY: "amd64"})
 
     # Assert
     with pytest.raises(RuntimeError):
@@ -25,7 +25,7 @@ def test_ImageManifest_cname() -> None:
     cname = "container-amd64-today-local"
 
     empty_manifest = ImageManifest()
-    manifest = ImageManifest(annotations={"cname": cname})
+    manifest = ImageManifest(annotations={ImageManifest.ANNOTATION_CNAME_KEY: cname})
 
     # Assert
     with pytest.raises(RuntimeError):
@@ -42,7 +42,9 @@ def test_ImageManifest_feature_set() -> None:
     feature_set = "container"
 
     empty_manifest = ImageManifest()
-    manifest = ImageManifest(annotations={"feature_set": feature_set})
+    manifest = ImageManifest(
+        annotations={ImageManifest.ANNOTATION_FEATURE_SET_KEY: feature_set}
+    )
 
     # Assert
     with pytest.raises(RuntimeError):
@@ -60,7 +62,7 @@ def test_ImageManifest_flavor() -> None:
     cname = f"{flavor}-amd64-today-local"
 
     empty_manifest = ImageManifest()
-    manifest = ImageManifest(annotations={"cname": cname})
+    manifest = ImageManifest(annotations={ImageManifest.ANNOTATION_CNAME_KEY: cname})
 
     # Assert
     with pytest.raises(RuntimeError):
@@ -98,7 +100,9 @@ def test_ImageManifest_version() -> None:
     version = "today"
 
     empty_manifest = ImageManifest()
-    manifest = ImageManifest(annotations={"version": version})
+    manifest = ImageManifest(
+        annotations={ImageManifest.ANNOTATION_VERSION_KEY: version}
+    )
 
     # Assert
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends generated OCI image manifests with more standardized annotations.