### PR TITLE
Increase initial and default Podman socket timeout

### DIFF
--- a/src/gardenlinux/oci/podman.py
+++ b/src/gardenlinux/oci/podman.py
@@ -278,10 +278,13 @@ class Podman(object):
         :since: 1.0.0
         """
 
-        oci_data = oci_container_tag.rsplit(":", 1)
+        if ":" in oci_container_tag:
+            oci_data = oci_container_tag.rsplit(":", 1)
 
-        if len(oci_data) < 2:
-            raise RuntimeError("No tag given")
+            if len(oci_data) < 2:
+                raise RuntimeError("No tag given")
+        else:
+            oci_data = ["", oci_container_tag]
 
         image = podman.images.get(image_id)
         image.tag(oci_data[0], oci_data[1])

--- a/src/gardenlinux/oci/podman_context.py
+++ b/src/gardenlinux/oci/podman_context.py
@@ -137,15 +137,19 @@ class PodmanContext(ExitStack):
         :since: 1.0.0
         """
 
+        # Use variable for status to catch corner cases of fast closing sockets
+        is_socket_available = False
         sock_path = Path(sock)
 
-        for _ in range(0, 5 * PODMAN_CONNECTION_MAX_IDLE_SECONDS):
-            if sock_path.exists():
+        for _ in range(0, 50 * PODMAN_CONNECTION_MAX_IDLE_SECONDS):
+            is_socket_available = sock_path.exists()
+
+            if is_socket_available:
                 break
 
             sleep(0.2)
 
-        if not sock_path.exists():
+        if not is_socket_available:
             raise TimeoutError()
 
     @staticmethod


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the Podman socket timeouts to fix #336. As Podman execution on GitHub arm64 runners takes too long for the former timeout we multiply the connection timeout there.

**Which issue(s) this PR fixes**:
Fixes #336

**Special notes for your reviewer**:
Requires #335