### PR TITLE
Adding sbom as application/json to supported mediatypes

### DIFF
--- a/src/gardenlinux/constants.py
+++ b/src/gardenlinux/constants.py
@@ -98,6 +98,7 @@ GL_MEDIA_TYPES = [
     "uki",
     "raw",
     "log",
+    "sbom"
 ]
 
 GL_MEDIA_TYPE_LOOKUP = {
@@ -141,6 +142,7 @@ GL_MEDIA_TYPE_LOOKUP = {
     "secureboot.db.auth": "application/io.gardenlinux.cert.secureboot.db.auth",
     "secureboot.db.arn": "application/io.gardenlinux.cert.secureboot.db.arn",
     "secureboot.aws-efivars": "application/io.gardenlinux.cert.secureboot.aws-efivars",
+    "sbom": "application/json"
 }
 
 GL_BUG_REPORT_URL = "https://github.com/gardenlinux/gardenlinux/issues"

--- a/src/gardenlinux/constants.py
+++ b/src/gardenlinux/constants.py
@@ -98,7 +98,7 @@ GL_MEDIA_TYPES = [
     "uki",
     "raw",
     "log",
-    "sbom"
+    "sbom",
 ]
 
 GL_MEDIA_TYPE_LOOKUP = {
@@ -142,7 +142,7 @@ GL_MEDIA_TYPE_LOOKUP = {
     "secureboot.db.auth": "application/io.gardenlinux.cert.secureboot.db.auth",
     "secureboot.db.arn": "application/io.gardenlinux.cert.secureboot.db.arn",
     "secureboot.aws-efivars": "application/io.gardenlinux.cert.secureboot.aws-efivars",
-    "sbom": "application/json"
+    "sbom": "application/json",
 }
 
 GL_BUG_REPORT_URL = "https://github.com/gardenlinux/gardenlinux/issues"

--- a/src/gardenlinux/constants.py
+++ b/src/gardenlinux/constants.py
@@ -88,6 +88,7 @@ GL_MEDIA_TYPES = [
     "initrd",
     "tar.gz",
     "qcow2",
+    "sbom",
     "tar",
     "iso",
     "oci",
@@ -98,7 +99,6 @@ GL_MEDIA_TYPES = [
     "uki",
     "raw",
     "log",
-    "sbom",
 ]
 
 GL_MEDIA_TYPE_LOOKUP = {
@@ -142,7 +142,7 @@ GL_MEDIA_TYPE_LOOKUP = {
     "secureboot.db.auth": "application/io.gardenlinux.cert.secureboot.db.auth",
     "secureboot.db.arn": "application/io.gardenlinux.cert.secureboot.db.arn",
     "secureboot.aws-efivars": "application/io.gardenlinux.cert.secureboot.aws-efivars",
-    "sbom": "application/json",
+    "sbom": "application/vnd.cyclonedx+json",
 }
 
 GL_BUG_REPORT_URL = "https://github.com/gardenlinux/gardenlinux/issues"


### PR DESCRIPTION
refs gardenlinux/gardenlinux#4993

On-behalf-of: SAP <b.ritter@sap.com>

**What this PR does / why we need it**:
Adds the sbom media type.

**Which issue(s) this PR fixes**:
Fixes #4993
