### PR TITLE
docs: remove "AI-generated phrasing"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To find our more, visit our
 ## Licensing
 
 Copyright 2025 SAP SE or an SAP affiliate company and GardenLinux contributors.
-Please see our [LICENSE](LICENSE.md) for copyright and license information.
+See our [LICENSE](LICENSE.md) for copyright and license information.
 Detailed information including third-party components and their
 licensing/copyright information is available
 [via the REUSE tool](https://reuse.software).

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -35,7 +35,7 @@ command line.
    - `pyproject.toml`
    - `.github/actions/setup/action.yml`
 
-   Additionally at the moment (removal pending):
+   Also at the moment (removal pending):
    - `.github/actions/features_parse/action.yml`
    - `.github/actions/flavors_parse/action.yml`
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -22,7 +22,7 @@ artifacts, S3 buckets, and GitHub releases.
 
 ## Overview
 
-The Garden Linux Python Library is a comprehensive toolkit for managing and
+The Garden Linux Python Library is a toolkit for managing and
 interacting with Garden Linux components. It includes:
 
 - **Feature Management**: Parse and work with Garden Linux features and generate

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -14,7 +14,7 @@ github_source_path: docs/overview/index.md
 github_target_path: "docs/reference/supporting_tools/python-gardenlinux-lib.md"
 ---
 
-# Garden Linux Python Library Documentation
+# Garden Linux Python library documentation
 
 Welcome to the Garden Linux Python Library documentation. This library provides
 Python tools and utilities for working with Garden Linux features, flavors, OCI
@@ -78,7 +78,7 @@ For more examples and for all CLI tools, see the **Command-Line Interface** and
 **API Reference** sections in the docs:
 [https://gardenlinux.github.io/python-gardenlinux-lib/](https://gardenlinux.github.io/python-gardenlinux-lib/)
 
-## Quick Start
+## Quick start
 
 ### Command-Line Interface
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes "AI-generated phrasing". Definitions what qualifies at such phrasing [as documented](https://github.com/gardenlinux/docs-ng/blob/ae2f8301aa7673444fea3b7b794603fc951e9c31/docs/contributing/documentation/writing_good_docs.md#ai-generated-phrasing-to-avoid).
The removal of the phrases was done via the [documentation-humanize workflow](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/workflows/documentation-humanize.md) and [skill](https://github.com/gardenlinux/agent-skills/blob/b4681613ef763884f4e80d4ffb29649d160121a5/skills/documentation-humanize/SKILL.md).