### PR TITLE
feat: remove migration frontmatter as migration is done

### DIFF
--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -5,9 +5,6 @@ related_topics:
   - /reference/supporting_tools/python-gardenlinux-lib
   - /reference/python-gardenlinux-lib-cli
   - /how-to/python-gardenlinux-lib-release
-migration_status: "done"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: python-gardenlinux-lib
 github_source_path: docs/how-to/release.md

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -5,9 +5,6 @@ related_topics:
   - /reference/supporting_tools/python-gardenlinux-lib
   - /reference/python-gardenlinux-lib-cli
   - /how-to/python-gardenlinux-lib-release
-migration_status: "done"
-migration_stakeholder: "@tmangold, @yeoldegrove, @ByteOtter"
-migration_approved: false
 github_org: gardenlinux
 github_repo: python-gardenlinux-lib
 github_source_path: docs/overview/index.md


### PR DESCRIPTION
**What this PR does / why we need it**:

In https://github.com/gardenlinux/gardenlinux/issues/4332 we used migration markers in the frontmatter to track the migration status. These can now be removed as the documentation system is live.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5048
