### PR TITLE
Add support for publishing_group per ADR0037

### DIFF
--- a/src/gardenlinux/s3/s3_artifacts.py
+++ b/src/gardenlinux/s3/s3_artifacts.py
@@ -153,6 +153,7 @@ class S3Artifacts(object):
         require_uefi = None
         secureboot = None
         tpm2 = None
+        publishing_group = None
 
         if requirements_file.exists():
             requirements_config = ConfigParser(allow_unnamed_section=True)
@@ -171,6 +172,11 @@ class S3Artifacts(object):
 
             if requirements_config.has_option(UNNAMED_SECTION, "tpm2"):
                 tpm2 = requirements_config.getboolean(UNNAMED_SECTION, "tpm2")
+
+            if requirements_config.has_option(UNNAMED_SECTION, "publishing_group"):
+                publishing_group = requirements_config.get(
+                    UNNAMED_SECTION, "publishing_group"
+                )
 
         if arch is None:
             raise RuntimeError(
@@ -219,6 +225,9 @@ class S3Artifacts(object):
 
         if platform_variant is not None:
             metadata["platform_variant"] = platform_variant
+
+        if publishing_group:
+            metadata["publishing_group"] = publishing_group
 
         base_name_length = len(base_name)
 

--- a/tests/s3/test_s3_artifacts.py
+++ b/tests/s3/test_s3_artifacts.py
@@ -302,3 +302,49 @@ def test_upload_directory_with_requirements_override(s3_setup: S3Env) -> None:
     metadata = yaml.safe_load(meta_obj.get()["Body"].read())
     assert metadata["require_uefi"] is False
     assert metadata["secureboot"] is True
+
+
+def test_upload_directory_with_publishing_group(s3_setup: S3Env) -> None:
+    """A publishing_group value in the .requirements file is copied into the metadata."""
+    # Arrange
+    env = s3_setup
+    (env.tmp_path / f"{env.cname}.release").write_text(RELEASE_DATA)
+    (env.tmp_path / f"{env.cname}.requirements").write_text(
+        "arch = amd64\npublishing_group = container\n"
+    )
+    (env.tmp_path / f"{env.cname}-artifact").write_bytes(b"abc")
+
+    # Act
+    artifacts = S3Artifacts(env.bucket_name)
+    artifacts.upload_from_directory(env.cname, env.tmp_path)
+
+    # Assert
+    bucket = env.s3.Bucket(env.bucket_name)
+    meta_obj = next(
+        o for o in bucket.objects.all() if o.key == f"meta/singles/{env.cname}"
+    )
+    metadata = yaml.safe_load(meta_obj.get()["Body"].read())
+    assert metadata["publishing_group"] == "container"
+
+
+def test_upload_directory_without_publishing_group(s3_setup: S3Env) -> None:
+    """An empty or absent publishing_group is not emitted, marking a standalone build."""
+    # Arrange
+    env = s3_setup
+    (env.tmp_path / f"{env.cname}.release").write_text(RELEASE_DATA)
+    (env.tmp_path / f"{env.cname}.requirements").write_text(
+        "arch = amd64\npublishing_group = \n"
+    )
+    (env.tmp_path / f"{env.cname}-artifact").write_bytes(b"abc")
+
+    # Act
+    artifacts = S3Artifacts(env.bucket_name)
+    artifacts.upload_from_directory(env.cname, env.tmp_path)
+
+    # Assert
+    bucket = env.s3.Bucket(env.bucket_name)
+    meta_obj = next(
+        o for o in bucket.objects.all() if o.key == f"meta/singles/{env.cname}"
+    )
+    metadata = yaml.safe_load(meta_obj.get()["Body"].read())
+    assert "publishing_group" not in metadata


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for passing publishing_group in the manifest to GLCI, per ADR0037.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for publishing_group
```
